### PR TITLE
Add .env example and setup instructions

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your-key-here

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Voice Playground
+
+This project experiments with multiple speech-to-text and voice agent services using Next.js.
+
+## Setup
+
+1. Install dependencies with `npm install`.
+2. Copy `.env.local.example` to `.env.local`:
+   ```sh
+   cp .env.local.example .env.local
+   ```
+3. Edit `.env.local` and replace `your-key-here` with your actual OpenAI API key.
+4. Run the development server:
+   ```sh
+   npm run dev
+   ```


### PR DESCRIPTION
## Summary
- add example `.env.local` file
- document how to copy it to `.env.local` in the README

## Testing
- `npm run lint` *(fails: couldn't find `pages` or `app` directory)*
- `npm run build` *(fails: couldn't find `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_686823215bd8832e805506693a487294