### PR TITLE
Add chat page, transcribe API, and mic component

### DIFF
--- a/app/api/transcribe/route.ts
+++ b/app/api/transcribe/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { experimental_transcribe as transcribe } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+export async function POST(req: NextRequest) {
+  const audio = await req.arrayBuffer();
+  const start = Date.now();
+  const result = await transcribe({
+    model: openai.transcription('whisper-1'),
+    audio,
+  });
+  console.log('whisper latency ms', Date.now() - start);
+  return NextResponse.json({ transcript: result.text });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,9 @@
+export const metadata = { title: 'Voice Playground' };
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useChat } from '@ai-sdk/react';
+import { useEffect, useRef } from 'react';
+import Microphone from '../components/Microphone';
+
+export default function Page() {
+  const { messages, input, handleInputChange, handleSubmit, append } = useChat();
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  return (
+    <div className="flex flex-col h-screen p-4">
+      <div className="flex-1 overflow-y-auto space-y-2">
+        {messages.map((m, i) => (
+          <div key={i} className="whitespace-pre-wrap">
+            <b>{m.role}:</b> {m.content}
+          </div>
+        ))}
+        <div ref={endRef} />
+      </div>
+      <form onSubmit={handleSubmit} className="flex gap-2 mt-4">
+        <input
+          value={input}
+          onChange={handleInputChange}
+          className="flex-1 border p-2"
+          placeholder="Say something"
+        />
+        <button type="submit" className="border px-4">Send</button>
+        <Microphone onTranscript={(t) => append({ role: 'user', content: t })} />
+      </form>
+    </div>
+  );
+}

--- a/components/Microphone.tsx
+++ b/components/Microphone.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useRef, useState } from 'react';
+
+interface Props {
+  onTranscript: (text: string) => void;
+}
+
+export default function Microphone({ onTranscript }: Props) {
+  const [recording, setRecording] = useState(false);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+
+  async function toggle() {
+    if (recording) {
+      recorderRef.current?.stop();
+      recorderRef.current?.stream.getTracks().forEach((t) => t.stop());
+      setRecording(false);
+      return;
+    }
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const recorder = new MediaRecorder(stream, { mimeType: 'audio/webm' });
+    recorderRef.current = recorder;
+    recorder.ondataavailable = async (e) => {
+      if (e.data.size === 0) return;
+      const start = performance.now();
+      const res = await fetch('/api/transcribe', { method: 'POST', body: e.data });
+      const json = await res.json();
+      console.log('transcribe latency', performance.now() - start);
+      if (json.transcript) onTranscript(json.transcript as string);
+    };
+    recorder.start(250);
+    setRecording(true);
+  }
+
+  return (
+    <button type="button" onClick={toggle} className="border px-2">
+      {recording ? 'Stop' : 'Mic'}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- implement app router with a chat page using `useChat`
- add microphone component that records audio and posts to `/api/transcribe`
- create `/api/transcribe` route using AI SDK's `experimental_transcribe` with OpenAI
- minimal root layout for Next.js

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686823145af8832e8cbd68a50c5367d7